### PR TITLE
Fix HIGH: pin jekyll-terser + enable cookie consent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,8 @@ group :jekyll_plugins do
     gem 'jekyll-sitemap'
     gem 'jekyll-socials'
     gem 'jekyll-tabs'
-    gem 'jekyll-terser', :git => "https://github.com/RobertoJBeltran/jekyll-terser.git"
+    gem 'jekyll-terser', :git => "https://github.com/RobertoJBeltran/jekyll-terser.git",
+                        :ref => "1085bf66d692799af09fe39f8162a1e6e42a3cc4"
     gem 'jekyll-toc'
     gem 'jekyll-twitter-plugin'
     gem 'jemoji'

--- a/_config.yml
+++ b/_config.yml
@@ -272,7 +272,10 @@ lazy_loading_images: true
 
 enable_google_analytics: false
 enable_google_verification: false
-enable_cookie_consent: false
+# WARNING: cookie consent MUST be enabled before activating any analytics provider.
+# Analytics scripts are gated behind their own flags, but without cookie consent
+# they would fire immediately — violating GDPR. Keep this true as a safeguard.
+enable_cookie_consent: true
 enable_masonry: false
 enable_math: true
 enable_tooltips: false


### PR DESCRIPTION
## Summary
- **#3** Pin `jekyll-terser` gem to commit `1085bf66d692799af09fe39f8162a1e6e42a3cc4` to eliminate supply chain risk from the unverified Git fork.
- **#2** Enable `enable_cookie_consent: true` by default so that any analytics provider, if accidentally toggled on, cannot fire without user consent (GDPR safeguard).

Closes #3
Closes #2

## Test plan
- [ ] Verify `bundle install` still resolves jekyll-terser correctly at the pinned commit
- [ ] Verify cookie consent banner appears when loading the site locally
- [ ] Verify analytics scripts remain inert (their own flags are still `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)