### PR TITLE
fix: QA medium+low — jQuery 3.7.1 and enable JS minification

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,7 +156,7 @@ sass:
 # -----------------------------------------------------------------------------
 
 jekyll-minifier:
-  compress_javascript: false
+  compress_javascript: true
   exclude: ["robots.txt", "assets/js/search/*.js"]
 
 # -----------------------------------------------------------------------------
@@ -312,10 +312,10 @@ third_party_libraries:
     version: "11.9.0"
   jquery:
     integrity:
-      js: "sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
+      js: "sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
     url:
       js: "https://cdn.jsdelivr.net/npm/jquery@{{version}}/dist/jquery.min.js"
-    version: "3.6.0"
+    version: "3.7.1"
   mathjax:
     integrity:
       js: "sha256-MASABpB4tYktI2Oitl4t+78w/lyA+D7b/s9GEP0JOGI="


### PR DESCRIPTION
## Summary
- **#4 (medium)**: Update jQuery CDN from 3.6.0 to 3.7.1 (bug fixes + security patches)
- **#1 (low)**: Enable `compress_javascript: true` in jekyll-minifier for smaller page loads

Closes #4
Closes #1

## Test plan
- [ ] Verify site builds without errors after jQuery update
- [ ] Verify JS files are minified in production build output
- [ ] Check no JS functionality is broken by minification