### PR TITLE
fix: point canonical URL and og:image to jrmsaavedra.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ keywords: José Ramón Martínez Saavedra, Quside, quantum random number generat
 lang: en
 icon: ⚛️
 
-url: https://joseramasa.github.io
+url: https://jrmsaavedra.com
 baseurl:
 last_updated: true
 back_to_top: true
@@ -43,7 +43,7 @@ max_width: 930px
 
 serve_og_meta: true
 serve_schema_org: true
-og_image: assets/img/prof_pic.jpg
+og_image: https://jrmsaavedra.com/assets/img/prof_pic.jpg
 
 # -----------------------------------------------------------------------------
 # Blog


### PR DESCRIPTION
Now that jrmsaavedra.com is the live custom domain, the build metadata still pointed to the old `joseramasa.github.io`:

- **`url`** → `https://jrmsaavedra.com` — fixes `canonical`, `og:url`, JSON-LD `@id`/`url`, sitemap and RSS (all were emitting the old domain, which only 301-redirects).
- **`og_image`** → absolute URL — al-folio emits `site.og_image` verbatim, so a relative path meant **LinkedIn/WhatsApp/Twitter previews showed no image**. Now absolute.

Note: `twitter:card` stays `summary` — upgrading to `summary_large_image` would need a dedicated 1200×630 image (current one is a portrait). Left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)