### PR TITLE
fix: remove redundant self-as-instructor from Bari seminars

### DIFF
--- a/_teachings/bari-quantum-seminars.md
+++ b/_teachings/bari-quantum-seminars.md
@@ -2,7 +2,6 @@
 layout: course
 title: PQC & QRNG Seminars — Università di Bari
 description: Invited seminars on Post-Quantum Cryptography and Quantum Random Number Generation at the Master of Quantum Science and Technology.
-instructor: José R. Martínez Saavedra
 year: 2025
 term: Summer
 location: Università degli Studi di Bari Aldo Moro, Italy


### PR DESCRIPTION
Follow-up to #8: the second teaching entry (Bari seminars) had the same redundant `instructor` field, rendering as "Summer José R. Martínez Saavedra" run-together in the course list. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)