### PR TITLE
content: clarify patents, signal Spanish content, add NanophotonicsLab post

### DIFF
--- a/_news/announcement_7.md
+++ b/_news/announcement_7.md
@@ -5,4 +5,4 @@ inline: true
 related_posts: false
 ---
 
-Launched two outreach projects: [**El Fotonario**](https://joseramasa.github.io/fotonica/) — an interactive photonics course in Spanish — and [**Con la Venia**](https://joseramasa.github.io/con-la-venia/) — a visual novel for learning civil procedural law.
+Launched two outreach projects: [**El Fotonario**](https://joseramasa.github.io/fotonica/) — an interactive photonics course in Spanish — and [**Con la Venia**](https://joseramasa.github.io/con-la-venia/) — a visual novel (in Spanish) for learning civil procedural law.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -25,10 +25,10 @@ latest_posts:
 
 I build deployable quantum-randomness infrastructure for **cybersecurity**, **high-performance computing**, and **post-quantum** systems — taking quantum physics from the lab to real-world products.
 
-VP of Innovation and Lead Scientist at [Quside Technologies](https://quside.com). Co-inventor across **8 patent families** (US, EP, CN, JP). PI of **€5.6M+** in competitive R&D funding ([Horizon Europe/EIC](https://cordis.europa.eu/project/id/101145131), CDTI). 30+ patent families under management.
+VP of Innovation and Lead Scientist at [Quside Technologies](https://quside.com). PI of **€5.6M+** in competitive R&D funding ([Horizon Europe/EIC](https://cordis.europa.eu/project/id/101145131), CDTI). Co-inventor of **8 patent families** (US, EP, CN, JP); I also oversee Quside's IP portfolio of 30+ patent families.
 
 At Quside I lead R&D strategy and technology transfer — from quantum random number generators to post-quantum cryptography stacks and entropy infrastructure at scale. I bridge the gap between our photonics hardware and the software and systems that make it deployable.
 
 **Ph.D. in Photonics** (UPC/ICFO, 2018, *Cum Laude*; advisor: F. J. García de Abajo). **MBA** (Valar Institute, 2025). Physics at Universidad Complutense de Madrid. Currently pursuing a **Law degree** (UOC) at the intersection of technology, IP, and regulation.
 
-I teach [*Software Architecture for Quantum Computers*](https://upcschool.upc.edu/ing/estudis/formacio/curs/304400/postgrau-enginyeria-quantica/) at UPC, supervise doctoral theses at UPC and ICFO, and build open educational tools like [NanophotonicsLab](https://nanophotonicslab.com/) and [El Fotonario](https://joseramasa.github.io/fotonica/).
+I teach [*Software Architecture for Quantum Computers*](https://upcschool.upc.edu/ing/estudis/formacio/curs/304400/postgrau-enginyeria-quantica/) at UPC, supervise doctoral theses at UPC and ICFO, and build open educational tools like [NanophotonicsLab](https://nanophotonicslab.com/) and [El Fotonario](https://joseramasa.github.io/fotonica/) *(in Spanish)*.

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -45,7 +45,7 @@ nav_order: 3
 ## Conferences and Seminars
 
 ### 2026
-- **QRNG for Cybersecurity and Blockchain** — [QSecDef](https://www.quantumsecuritydefence.com/qrng) certified training course. Co-authored and co-presented with David Worrall. January 21, 2026. (4–5 hours; being edited for release)
+- **QRNG for Cybersecurity and Blockchain** — [QSecDef](https://www.quantumsecuritydefence.com/qrng) certified training course. Co-authored and co-presented with David Worrall. January 21, 2026. (4–5 hours)
 
 ### 2025
 - **"Desde la cuántica hasta la nube: Generación de números aleatorios con tecnologías fotónicas de última generación"** — Invited seminar, UCM (Prof. Gemma Piquero Sanz). September 2025. [(slides)](/assets/teaching/ucm-qrng-2025.pdf)

--- a/_posts/2026-06-09-nanophotonicslab.md
+++ b/_posts/2026-06-09-nanophotonicslab.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "NanophotonicsLab: nanophotonics simulation in the browser"
+date: 2026-06-09
+description: "An open, no-install toolkit for simulating light–matter interactions at the nanoscale — Mie scattering, plasmonics, RCWA, and more."
+tags: [photonics, outreach]
+---
+
+I've just launched [NanophotonicsLab](https://nanophotonicslab.com/), an open toolkit for simulating nanophotonics directly in the browser — no installation, no licenses, no setup.
+
+It bundles the calculations I kept re-deriving through my PhD and beyond into interactive tools: Mie scattering and cross-sections, the optical response of plasmonic nanoparticles, cylindrical scatterers, photothermal heating, electron- and photon-based simulators, the Beam Propagation Method for waveguides, laser-cavity calculators, and Rigorous Coupled-Wave Analysis (RCWA) for periodic structures.
+
+### Why?
+
+Nanophotonics simulation usually means wrestling with installations, licenses, or writing code from scratch before you can build any intuition. For a student trying to understand *why* a gold nanoparticle scatters the colors it does, that friction is the whole problem. NanophotonicsLab removes it: open a tab, move a slider, watch the physics respond.
+
+Everything runs client-side, works offline via a service worker, and is free.
+
+### What's next
+
+More solvers, more geometries, and teaching material built on top of the tools. If you teach or research nanophotonics and want to use it — or you find something wrong — I'd like to hear from you.
+
+[Try it here.](https://nanophotonicslab.com/)


### PR DESCRIPTION
Editorial fixes from the site audit (all approved).

- **Patents (about)** — split the *8 patent families* (co-inventor) from the *30+ under management* (portfolio oversight); they were in one sentence and read as one confusing number.
- **Spanish content signalling** — mark *El Fotonario* and *Con la Venia* as "(in Spanish)" in `about.md` and the launch announcement, so English-speaking visitors know before clicking.
- **NanophotonicsLab post (draft)** — the notes section had two posts from March and nothing since; the June launch had a news entry but no post. Added one in the same voice/format as the existing posts. **Review the wording.**
- **research** — removed the internal "being edited for release" note.

Not included (needs your call): the CV ↔ research thesis-supervision de-dup — see chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)