### PR TITLE
fix: PQC paper published (ICTON 2025), pro email, Coherent news

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,12 +1,14 @@
 ---
 ---
 
-@article{blanco2025pqc,
-  abbr      = {arXiv},
+@inproceedings{blanco2025pqc,
+  abbr      = {ICTON},
   title     = {Integration of quantum random number generators with post-quantum cryptography algorithms},
   author    = {Blanco, PA and Vidarte, LT and Casas, MR and Martínez Saavedra, JR and de la Iglesia, F},
-  journal   = {arXiv preprint arXiv:2507.00658},
+  booktitle = {2025 25th Anniversary International Conference on Transparent Optical Networks (ICTON)},
   year      = {2025},
+  publisher = {IEEE},
+  doi       = {10.1109/ICTON67126.2025.11125447},
   pdf       = {2025-pqc-qrng.pdf},
   html      = {https://arxiv.org/abs/2507.00658},
   selected  = {true}

--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -1,4 +1,4 @@
-email: jrmsaavedra@gmail.com
+email: jose@jrmsaavedra.com
 scholar_userid: wyZ69W0AAAAJ
 github_username: joseramasa
 linkedin_username: jrmsaavedra

--- a/_news/announcement_10.md
+++ b/_news/announcement_10.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-01-20
+inline: true
+related_posts: false
+---
+
+[Quside](https://quside.com) and [Coherent](https://www.coherent.com) demonstrated a scalable, mass-manufacturable **quantum entropy source** — Coherent's 6″ VCSEL production combined with Quside's quantum random number generation, with runtime entropy verification — shown live with development kits at [Photonics West 2026](https://www.coherent.com/news/press-releases/coherent-and-quside-demonstrate-verifiable-entropy-for-quantum-safe-encryption).


### PR DESCRIPTION
- **PQC paper is now published** — no longer a preprint. Appeared in the *ICTON 2025* proceedings (IEEE Xplore, doc 11125447). Changed `@article` → `@inproceedings` with DOI `10.1109/ICTON67126.2025.11125447` (verified via Crossref + arXiv related-DOI). arXiv link kept; local PDF is already byte-identical to arXiv v2 (27 Aug 2025).
- **Footer email** → `jose@jrmsaavedra.com` (was gmail).
- **News** — added the public Quside × Coherent quantum-entropy / VCSEL milestone (Photonics West 2026). *Reword or drop if you'd rather a personal angle.*

Note: this deploy also flushes the CDN cache still serving "FJ Abajo" (already fixed at source in #12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)