### PR TITLE
fix: add /news/ archive page (homepage heading 404'd)

### DIFF
--- a/_pages/news.md
+++ b/_pages/news.md
@@ -1,0 +1,11 @@
+---
+layout: page
+permalink: /news/
+title: news
+description: Announcements and updates.
+nav: false
+---
+
+<div class="post">
+  {% include news.liquid %}
+</div>


### PR DESCRIPTION
The homepage "news" heading links to `/news/`, which returned 404 (no `_pages/news.md`). Adds the archive page rendering the full announcements list via the existing `news.liquid` include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)