### PR TITLE
ci: switch to artifact-based Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,11 +61,19 @@ on:
       - "!README.md"
   workflow_dispatch:
 
+# Artifact-based GitHub Pages deploy (single step, no gh-pages branch).
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     # available images: https://github.com/actions/runner-images#available-images
     runs-on: ubuntu-latest
     steps:
@@ -98,8 +106,21 @@ jobs:
         run: |
           npm install -g purgecss
           purgecss -c purgecss.config.js
-      - name: Deploy 🚀
+      - name: Upload Pages artifact 📦
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: _site
+          path: _site
+
+  deploy:
+    # Only deploy on push (PRs just build to validate).
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaces the two-hop publish (JamesIves → gh-pages branch → GitHub's native "pages build and deployment") with a single artifact-based deploy (`upload-pages-artifact` + `actions/deploy-pages`).

**Why:** the native build occasionally failed transiently ("Deployment failed, try again later") while `Deploy site` showed green, silently freezing the live site. One deploy step removes that failure mode.

Same build (Ruby/Jekyll + PurgeCSS); only the publish mechanism changes. Pairs with switching the Pages source to "GitHub Actions".

🤖 Generated with [Claude Code](https://claude.com/claude-code)