### PR TITLE
chore: gitignore Jekyll build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 bari/
 .DS_Store
+
+# Jekyll build artifacts
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/


### PR DESCRIPTION
Ignore `_site/` and Jekyll caches so local builds aren't committed (the site builds in CI now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)